### PR TITLE
Add support for HAProxyMessageEncoder

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
@@ -56,5 +56,23 @@ final class HAProxyConstants {
     static final byte TPAF_UNIX_STREAM_BYTE = 0x31;
     static final byte TPAF_UNIX_DGRAM_BYTE = 0x32;
 
+    /**
+     * V2 protocol binary header prefix
+     */
+    static final byte[] BINARY_PREFIX = {
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x00,
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x51,
+            (byte) 0x55,
+            (byte) 0x49,
+            (byte) 0x54,
+            (byte) 0x0A
+    };
+
     private HAProxyConstants() { }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
@@ -74,7 +74,7 @@ final class HAProxyConstants {
             (byte) 0x0A
     };
 
-    static final byte[] PROXY_PREFIX = {
+    static final byte[] TEXT_PREFIX = {
             (byte) 'P',
             (byte) 'R',
             (byte) 'O',

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
@@ -74,5 +74,13 @@ final class HAProxyConstants {
             (byte) 0x0A
     };
 
+    static final byte[] PROXY_PREFIX = {
+            (byte) 'P',
+            (byte) 'R',
+            (byte) 'O',
+            (byte) 'X',
+            (byte) 'Y',
+    };
+
     private HAProxyConstants() { }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -25,6 +25,7 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,9 +60,16 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
     }
 
     /**
-     * Creates a new instance
+     * Creates a new instance of HAProxyMessage.
+     * @param protocolVersion the protocol version.
+     * @param command the command.
+     * @param proxiedProtocol the protocol containing the address family and transport protocol.
+     * @param sourceAddress the source address.
+     * @param destinationAddress the destination address.
+     * @param sourcePort the source port. This value must be 0 for unix, unspec addresses.
+     * @param destinationPort the destination port. This value must be 0 for unix, unspec addresses.
      */
-    private HAProxyMessage(
+    public HAProxyMessage(
             HAProxyProtocolVersion protocolVersion, HAProxyCommand command, HAProxyProxiedProtocol proxiedProtocol,
             String sourceAddress, String destinationAddress, int sourcePort, int destinationPort) {
 
@@ -70,20 +78,29 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
     }
 
     /**
-     * Creates a new instance
+     * Creates a new instance of HAProxyMessage.
+     * @param protocolVersion the protocol version.
+     * @param command the command.
+     * @param proxiedProtocol the protocol containing the address family and transport protocol.
+     * @param sourceAddress the source address.
+     * @param destinationAddress the destination address.
+     * @param sourcePort the source port. This value must be 0 for unix, unspec addresses.
+     * @param destinationPort the destination port. This value must be 0 for unix, unspec addresses.
+     * @param tlvs the list of tlvs.
      */
-    private HAProxyMessage(
+    public HAProxyMessage(
             HAProxyProtocolVersion protocolVersion, HAProxyCommand command, HAProxyProxiedProtocol proxiedProtocol,
             String sourceAddress, String destinationAddress, int sourcePort, int destinationPort,
-            List<HAProxyTLV> tlvs) {
+            List<? extends HAProxyTLV> tlvs) {
 
         ObjectUtil.checkNotNull(proxiedProtocol, "proxiedProtocol");
+        ObjectUtil.checkNotNull(tlvs, "tlvs");
         AddressFamily addrFamily = proxiedProtocol.addressFamily();
 
         checkAddress(sourceAddress, addrFamily);
         checkAddress(destinationAddress, addrFamily);
-        checkPort(sourcePort);
-        checkPort(destinationPort);
+        checkPort(sourcePort, addrFamily);
+        checkPort(destinationPort, addrFamily);
 
         this.protocolVersion = protocolVersion;
         this.command = command;
@@ -329,9 +346,13 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
             throw new HAProxyProtocolException("invalid TCP4/6 header: " + header + " (expected: 6 parts)");
         }
 
-        return new HAProxyMessage(
-                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,
-                protAndFam, parts[2], parts[3], parts[4], parts[5]);
+        try {
+            return new HAProxyMessage(
+                    HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,
+                    protAndFam, parts[2], parts[3], parts[4], parts[5]);
+        } catch (Exception e) {
+            throw new HAProxyProtocolException("invalid HAProxy message", e);
+        }
     }
 
     /**
@@ -373,18 +394,18 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
      *
      * @param value                      the port
      * @return                           port as an integer
-     * @throws HAProxyProtocolException  if port is not a valid integer
+     * @throws IllegalArgumentException  if port is not a valid integer
      */
     private static int portStringToInt(String value) {
         int port;
         try {
             port = Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            throw new HAProxyProtocolException("invalid port: " + value, e);
+            throw new IllegalArgumentException("invalid port: " + value, e);
         }
 
         if (port <= 0 || port > 65535) {
-            throw new HAProxyProtocolException("invalid port: " + value + " (expected: 1 ~ 65535)");
+            throw new IllegalArgumentException("invalid port: " + value + " (expected: 1 ~ 65535)");
         }
 
         return port;
@@ -395,7 +416,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
      *
      * @param address                    human-readable address
      * @param addrFamily                 the {@link AddressFamily} to check the address against
-     * @throws HAProxyProtocolException  if the address is invalid
+     * @throws IllegalArgumentException  if the address is invalid
      */
     private static void checkAddress(String address, AddressFamily addrFamily) {
         ObjectUtil.checkNotNull(addrFamily, "addrFamily");
@@ -403,10 +424,13 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
         switch (addrFamily) {
             case AF_UNSPEC:
                 if (address != null) {
-                    throw new HAProxyProtocolException("unable to validate an AF_UNSPEC address: " + address);
+                    throw new IllegalArgumentException("unable to validate an AF_UNSPEC address: " + address);
                 }
                 return;
             case AF_UNIX:
+                if (address == null || address.getBytes(CharsetUtil.US_ASCII).length > 108) {
+                    throw new IllegalArgumentException("invalid AF_UNIX address: " + address);
+                }
                 return;
         }
 
@@ -415,28 +439,41 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
         switch (addrFamily) {
             case AF_IPv4:
                 if (!NetUtil.isValidIpV4Address(address)) {
-                    throw new HAProxyProtocolException("invalid IPv4 address: " + address);
+                    throw new IllegalArgumentException("invalid IPv4 address: " + address);
                 }
                 break;
             case AF_IPv6:
                 if (!NetUtil.isValidIpV6Address(address)) {
-                    throw new HAProxyProtocolException("invalid IPv6 address: " + address);
+                    throw new IllegalArgumentException("invalid IPv6 address: " + address);
                 }
                 break;
             default:
-                throw new Error();
+                throw new IllegalArgumentException("unexpected addrFamily: " + addrFamily);
         }
     }
 
     /**
-     * Validate a UDP/TCP port
+     * Validate the port depending on the addrFamily.
      *
      * @param port                       the UDP/TCP port
-     * @throws HAProxyProtocolException  if the port is out of range (0-65535 inclusive)
+     * @throws IllegalArgumentException  if the port is out of range (0-65535 inclusive)
      */
-    private static void checkPort(int port) {
-        if (port < 0 || port > 65535) {
-            throw new HAProxyProtocolException("invalid port: " + port + " (expected: 1 ~ 65535)");
+    private static void checkPort(int port, AddressFamily addrFamily) {
+        switch (addrFamily) {
+        case AF_IPv6:
+        case AF_IPv4:
+            if (port < 0 || port > 65535) {
+                throw new IllegalArgumentException("invalid port: " + port + " (expected: 1 ~ 65535)");
+            }
+            break;
+        case AF_UNIX:
+        case AF_UNSPEC:
+            if (port != 0) {
+                throw new IllegalArgumentException("port cannot be specified with addrFamily: " + addrFamily);
+            }
+            break;
+        default:
+            throw new IllegalArgumentException("unexpected addrFamily: " + addrFamily);
         }
     }
 
@@ -498,6 +535,14 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
         return tlvs;
     }
 
+    int tlvNumBytes() {
+        int tlvNumBytes = 0;
+        for (int i = 0; i < tlvs.size(); i++) {
+            tlvNumBytes += tlvs.get(i).totalNumBytes();
+        }
+        return tlvNumBytes;
+    }
+
     @Override
     public HAProxyMessage touch() {
         tryRecord();
@@ -555,5 +600,27 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
                 assert closed;
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(256)
+                .append(StringUtil.simpleClassName(this))
+                .append("(protocolVersion: ").append(protocolVersion)
+                .append(", command: ").append(command)
+                .append(", proxiedProtocol: ").append(proxiedProtocol)
+                .append(", sourceAddress: ").append(sourceAddress)
+                .append(", destinationAddress: ").append(destinationAddress)
+                .append(", sourcePort: ").append(sourcePort)
+                .append(", destinationPort: ").append(destinationPort)
+                .append(", tlvs: [");
+        for (HAProxyTLV tlv: tlvs) {
+            sb.append(tlv).append(", ");
+        }
+        if (!tlvs.isEmpty()) {
+            sb.setLength(sb.length() - 2);
+        }
+        sb.append("])");
+        return sb.toString();
     }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -428,7 +428,8 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
                 }
                 return;
             case AF_UNIX:
-                if (address == null || address.getBytes(CharsetUtil.US_ASCII).length > 108) {
+                ObjectUtil.checkNotNull(address, "address");
+                if (address.getBytes(CharsetUtil.US_ASCII).length > 108) {
                     throw new IllegalArgumentException("invalid AF_UNIX address: " + address);
                 }
                 return;

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -465,7 +465,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
         case AF_IPv6:
         case AF_IPv4:
             if (port < 0 || port > 65535) {
-                throw new IllegalArgumentException("invalid port: " + port + " (expected: 1 ~ 65535)");
+                throw new IllegalArgumentException("invalid port: " + port + " (expected: 0 ~ 65535)");
             }
             break;
         case AF_UNIX:
@@ -616,10 +616,10 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
                 .append(", sourcePort: ").append(sourcePort)
                 .append(", destinationPort: ").append(destinationPort)
                 .append(", tlvs: [");
-        for (HAProxyTLV tlv: tlvs) {
-            sb.append(tlv).append(", ");
-        }
         if (!tlvs.isEmpty()) {
+            for (HAProxyTLV tlv: tlvs) {
+                sb.append(tlv).append(", ");
+            }
             sb.setLength(sb.length() - 2);
         }
         sb.append("])");

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -93,6 +93,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
             String sourceAddress, String destinationAddress, int sourcePort, int destinationPort,
             List<? extends HAProxyTLV> tlvs) {
 
+        ObjectUtil.checkNotNull(protocolVersion, "protocolVersion");
         ObjectUtil.checkNotNull(proxiedProtocol, "proxiedProtocol");
         ObjectUtil.checkNotNull(tlvs, "tlvs");
         AddressFamily addrFamily = proxiedProtocol.addressFamily();

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -351,7 +351,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
             return new HAProxyMessage(
                     HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,
                     protAndFam, parts[2], parts[3], parts[4], parts[5]);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new HAProxyProtocolException("invalid HAProxy message", e);
         }
     }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -23,6 +23,8 @@ import io.netty.util.CharsetUtil;
 
 import java.util.List;
 
+import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+
 /**
  * Decodes an HAProxy proxy protocol header
  *
@@ -48,24 +50,6 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
      * Maximum possible length for v2 additional TLV data (max unsigned short - max v2 address info space)
      */
     private static final int V2_MAX_TLV = 65535 - 216;
-
-    /**
-     * Binary header prefix
-     */
-    private static final byte[] BINARY_PREFIX = {
-            (byte) 0x0D,
-            (byte) 0x0A,
-            (byte) 0x0D,
-            (byte) 0x0A,
-            (byte) 0x00,
-            (byte) 0x0D,
-            (byte) 0x0A,
-            (byte) 0x51,
-            (byte) 0x55,
-            (byte) 0x49,
-            (byte) 0x54,
-            (byte) 0x0A
-    };
 
     private static final byte[] TEXT_PREFIX = {
             (byte) 'P',

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -51,14 +51,6 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
      */
     private static final int V2_MAX_TLV = 65535 - 216;
 
-    private static final byte[] TEXT_PREFIX = {
-            (byte) 'P',
-            (byte) 'R',
-            (byte) 'O',
-            (byte) 'X',
-            (byte) 'Y',
-    };
-
     /**
      * Binary header prefix length
      */
@@ -338,7 +330,7 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
         if (match(BINARY_PREFIX, buffer, idx)) {
             return DETECTION_RESULT_V2;
         }
-        if (match(TEXT_PREFIX, buffer, idx)) {
+        if (match(PROXY_PREFIX, buffer, idx)) {
             return DETECTION_RESULT_V1;
         }
         return ProtocolDetectionResult.invalid();

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -330,7 +330,7 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
         if (match(BINARY_PREFIX, buffer, idx)) {
             return DETECTION_RESULT_V2;
         }
-        if (match(PROXY_PREFIX, buffer, idx)) {
+        if (match(TEXT_PREFIX, buffer, idx)) {
             return DETECTION_RESULT_V1;
         }
         return ProtocolDetectionResult.invalid();

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -89,12 +89,10 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
                 break;
             case AF_UNIX:
                 out.writeShort(TOTAL_UNIX_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes());
-                byte[] srcAddressBytes = msg.sourceAddress().getBytes(CharsetUtil.US_ASCII);
-                out.writeBytes(srcAddressBytes);
-                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - srcAddressBytes.length);
-                byte[] dstAddressBytes = msg.destinationAddress().getBytes(CharsetUtil.US_ASCII);
-                out.writeBytes(dstAddressBytes);
-                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - dstAddressBytes.length);
+                int srcAddrBytesWritten = out.writeCharSequence(msg.sourceAddress(), CharsetUtil.US_ASCII);
+                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - srcAddrBytesWritten);
+                int dstAddrBytesWritten = out.writeCharSequence(msg.destinationAddress(), CharsetUtil.US_ASCII);
+                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - dstAddrBytesWritten);
                 encodeTlvs(msg.tlvs(), out);
                 break;
             case AF_UNSPEC:

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -57,13 +57,17 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
     }
 
     private static void encodeV1(HAProxyMessage msg, ByteBuf out) {
-        final String protocol = msg.proxiedProtocol().name();
-        StringBuilder sb = new StringBuilder(108)
-                .append("PROXY ").append(protocol).append(' ')
-                .append(msg.sourceAddress()).append(' ')
-                .append(msg.destinationAddress()).append(' ')
-                .append(msg.sourcePort()).append(' ').append(msg.destinationPort()).append("\r\n");
-        out.writeCharSequence(sb.toString(), CharsetUtil.US_ASCII);
+        out.writeCharSequence("PROXY ", CharsetUtil.US_ASCII);
+        out.writeCharSequence(msg.proxiedProtocol().name(), CharsetUtil.US_ASCII);
+        out.writeCharSequence(" ", CharsetUtil.US_ASCII);
+        out.writeCharSequence(msg.sourceAddress(), CharsetUtil.US_ASCII);
+        out.writeCharSequence(" ", CharsetUtil.US_ASCII);
+        out.writeCharSequence(msg.destinationAddress(), CharsetUtil.US_ASCII);
+        out.writeCharSequence(" ", CharsetUtil.US_ASCII);
+        out.writeCharSequence(String.valueOf(msg.sourcePort()), CharsetUtil.US_ASCII);
+        out.writeCharSequence(" ", CharsetUtil.US_ASCII);
+        out.writeCharSequence(String.valueOf(msg.destinationPort()), CharsetUtil.US_ASCII);
+        out.writeCharSequence("\r\n", CharsetUtil.US_ASCII);
     }
 
     private static void encodeV2(HAProxyMessage msg, ByteBuf out) {
@@ -87,10 +91,10 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
                 out.writeShort(TOTAL_UNIX_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes());
                 byte[] srcAddressBytes = msg.sourceAddress().getBytes(CharsetUtil.US_ASCII);
                 out.writeBytes(srcAddressBytes);
-                out.writeBytes(new byte[UNIX_ADDRESS_BYTES_LENGTH - srcAddressBytes.length]);
+                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - srcAddressBytes.length);
                 byte[] dstAddressBytes = msg.destinationAddress().getBytes(CharsetUtil.US_ASCII);
                 out.writeBytes(dstAddressBytes);
-                out.writeBytes(new byte[UNIX_ADDRESS_BYTES_LENGTH - dstAddressBytes.length]);
+                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - dstAddressBytes.length);
                 encodeTlvs(msg.tlvs(), out);
                 break;
             case AF_UNSPEC:

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -47,12 +47,15 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
 
     @Override
     protected void encode(ChannelHandlerContext ctx, HAProxyMessage msg, ByteBuf out) throws Exception {
-        if (msg.protocolVersion() == HAProxyProtocolVersion.V1) {
-            encodeV1(msg, out);
-        } else if (msg.protocolVersion() == HAProxyProtocolVersion.V2) {
-            encodeV2(msg, out);
-        } else {
-            throw new HAProxyProtocolException("Unsupported version: " + msg.protocolVersion());
+        switch (msg.protocolVersion()) {
+            case V1:
+                encodeV1(msg, out);
+                break;
+            case V2:
+                encodeV2(msg, out);
+                break;
+            default:
+                throw new HAProxyProtocolException("Unsupported version: " + msg.protocolVersion());
         }
     }
 

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -60,7 +60,7 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
     }
 
     private static void encodeV1(HAProxyMessage msg, ByteBuf out) {
-        out.writeBytes(PROXY_PREFIX);
+        out.writeBytes(TEXT_PREFIX);
         out.writeByte((byte) ' ');
         out.writeCharSequence(msg.proxiedProtocol().name(), CharsetUtil.US_ASCII);
         out.writeByte((byte) ' ');

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+
+import java.util.List;
+
+import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+
+/**
+ * Encodes an HAProxy proxy protocol message
+ *
+ * @see <a href="http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
+ */
+@Sharable
+public class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMessage> {
+
+    private static final int V2_VERSION_BITMASK = 0x02 << 4;
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, HAProxyMessage msg, ByteBuf out) throws Exception {
+        if (msg.protocolVersion() == HAProxyProtocolVersion.V1) {
+            encodeV1(msg, out);
+        } else if (msg.protocolVersion() == HAProxyProtocolVersion.V2) {
+            encodeV2(msg, out);
+        } else {
+            throw new HAProxyProtocolException("Unsupported version: " + msg.protocolVersion());
+        }
+    }
+
+    private static void encodeV1(HAProxyMessage msg, ByteBuf out) {
+        final String protocol = msg.proxiedProtocol().name();
+        StringBuilder sb = new StringBuilder(108)
+                .append("PROXY ").append(protocol).append(' ')
+                .append(msg.sourceAddress()).append(' ')
+                .append(msg.destinationAddress()).append(' ')
+                .append(msg.sourcePort()).append(' ').append(msg.destinationPort()).append("\r\n");
+        out.writeBytes(sb.toString().getBytes(CharsetUtil.US_ASCII));
+    }
+
+    private static void encodeV2(HAProxyMessage msg, ByteBuf out) {
+        out.writeBytes(BINARY_PREFIX);
+        out.writeByte(V2_VERSION_BITMASK | msg.command().byteValue());
+        out.writeByte(msg.proxiedProtocol().byteValue());
+
+        if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_IPv4 ||
+            msg.proxiedProtocol().addressFamily() == AddressFamily.AF_IPv6) {
+            byte[] sourceAddress = NetUtil.createByteArrayFromIpAddressString(msg.sourceAddress());
+            byte[] destinationAddress = NetUtil.createByteArrayFromIpAddressString(msg.destinationAddress());
+            out.writeShort(sourceAddress.length + destinationAddress.length + 4 + msg.tlvNumBytes());
+            out.writeBytes(sourceAddress);
+            out.writeBytes(destinationAddress);
+            out.writeShort(msg.sourcePort());
+            out.writeShort(msg.destinationPort());
+            encodeTlvs(msg.tlvs(), out);
+        } else if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_UNIX) {
+            out.writeShort(216 + msg.tlvNumBytes());
+            byte[] srcAddressBytes = msg.sourceAddress().getBytes(CharsetUtil.US_ASCII);
+            out.writeBytes(srcAddressBytes);
+            out.writeBytes(new byte[108 - srcAddressBytes.length]);
+            byte[] dstAddressBytes = msg.destinationAddress().getBytes(CharsetUtil.US_ASCII);
+            out.writeBytes(dstAddressBytes);
+            out.writeBytes(new byte[108 - dstAddressBytes.length]);
+            encodeTlvs(msg.tlvs(), out);
+        } else if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_UNSPEC) {
+            out.writeShort(0);
+        }
+    }
+
+    private static void encodeTlv(HAProxyTLV haProxyTLV, ByteBuf out) {
+        if (haProxyTLV instanceof HAProxySSLTLV) {
+            HAProxySSLTLV ssltlv = (HAProxySSLTLV) haProxyTLV;
+            out.writeByte(haProxyTLV.typeByteValue());
+            out.writeShort(ssltlv.contentNumBytes());
+            out.writeByte(ssltlv.client());
+            out.writeInt(ssltlv.verify());
+            encodeTlvs(ssltlv.encapsulatedTLVs(), out);
+        } else {
+            out.writeByte(haProxyTLV.typeByteValue());
+            ByteBuf value = haProxyTLV.content();
+            int readableBytes = value.readableBytes();
+            out.writeShort(readableBytes);
+            out.writeBytes(value.readSlice(readableBytes));
+        }
+    }
+
+    private static void encodeTlvs(List<HAProxyTLV> haProxyTLVs, ByteBuf out) {
+        for (HAProxyTLV tlv: haProxyTLVs) {
+            encodeTlv(tlv, out);
+        }
+    }
+}

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
@@ -83,9 +83,13 @@ public final class HAProxySSLTLV extends HAProxyTLV {
         return (clientBitField & 0x4) != 0;
     }
 
+    /**
+     * Returns the client bit field
+     */
     public byte client() {
         return clientBitField;
     }
+
     /**
      * Returns the verification result
      */
@@ -111,13 +115,11 @@ public final class HAProxySSLTLV extends HAProxyTLV {
 
     @Override
     public String toString() {
-        return new StringBuilder(128)
-                .append(StringUtil.simpleClassName(this))
-                .append("(type: ").append(type())
-                .append(", typeByteValue: ").append(typeByteValue())
-                .append(", client: ").append(client())
-                .append(", verify: ").append(verify())
-                .append(", numEncapsulatedTlvs: ").append(tlvs.size())
-                .append(')').toString();
+        return StringUtil.simpleClassName(this) +
+               "(type: " + type() +
+               ", typeByteValue: " + typeByteValue() +
+               ", client: " + client() +
+               ", verify: " + verify() +
+               ", numEncapsulatedTlvs: " + tlvs.size() + ')';
     }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
@@ -17,6 +17,8 @@
 package io.netty.handler.codec.haproxy;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.internal.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +37,19 @@ public final class HAProxySSLTLV extends HAProxyTLV {
      * Creates a new HAProxySSLTLV
      *
      * @param verify the verification result as defined in the specification for the pp2_tlv_ssl struct (see
-     * http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)
+     * http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+     * @param clientBitField the bitfield with client information
+     * @param tlvs the encapsulated {@link HAProxyTLV}s
+     */
+    public HAProxySSLTLV(final int verify, final byte clientBitField, final List<HAProxyTLV> tlvs) {
+        this(verify, clientBitField, tlvs, Unpooled.EMPTY_BUFFER);
+    }
+
+    /**
+     * Creates a new HAProxySSLTLV
+     *
+     * @param verify the verification result as defined in the specification for the pp2_tlv_ssl struct (see
+     * http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
      * @param clientBitField the bitfield with client information
      * @param tlvs the encapsulated {@link HAProxyTLV}s
      * @param rawContent the raw TLV content
@@ -69,6 +83,9 @@ public final class HAProxySSLTLV extends HAProxyTLV {
         return (clientBitField & 0x4) != 0;
     }
 
+    public byte client() {
+        return clientBitField;
+    }
     /**
      * Returns the verification result
      */
@@ -83,4 +100,24 @@ public final class HAProxySSLTLV extends HAProxyTLV {
         return tlvs;
     }
 
+    @Override
+    int contentNumBytes() {
+        int tlvNumBytes = 0;
+        for (int i = 0; i < tlvs.size(); i++) {
+            tlvNumBytes += tlvs.get(i).totalNumBytes();
+        }
+        return 5 + tlvNumBytes; // clientBit(1) + verify(4) + tlvs
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128)
+                .append(StringUtil.simpleClassName(this))
+                .append("(type: ").append(type())
+                .append(", typeByteValue: ").append(typeByteValue())
+                .append(", client: ").append(client())
+                .append(", verify: ").append(verify())
+                .append(", numEncapsulatedTlvs: ").append(tlvs.size())
+                .append(')').toString();
+    }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.haproxy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.util.internal.StringUtil;
 
 import static io.netty.util.internal.ObjectUtil.*;
 
@@ -31,6 +32,18 @@ public class HAProxyTLV extends DefaultByteBufHolder {
 
     private final Type type;
     private final byte typeByteValue;
+
+    /**
+     * The size of this tlv in bytes.
+     * @return the number of bytes.
+     */
+    int totalNumBytes() {
+        return 3 + contentNumBytes(); // type(1) + length(2) + content
+    }
+
+    int contentNumBytes() {
+        return content().readableBytes();
+    }
 
     /**
      * The registered types a TLV can have regarding the PROXY protocol 1.5 spec
@@ -74,6 +87,45 @@ public class HAProxyTLV extends DefaultByteBufHolder {
                 return OTHER;
             }
         }
+
+        public static byte byteValueForType(final Type type) {
+            switch (type) {
+            case PP2_TYPE_ALPN:
+                return 0x01;
+            case PP2_TYPE_AUTHORITY:
+                return 0x02;
+            case PP2_TYPE_SSL:
+                return 0x20;
+            case PP2_TYPE_SSL_VERSION:
+                return 0x21;
+            case PP2_TYPE_SSL_CN:
+                return 0x22;
+            case PP2_TYPE_NETNS:
+                return 0x30;
+            default:
+                throw new IllegalArgumentException("unknown type: " + type);
+            }
+        }
+    }
+
+    /**
+     * Creates a new HAProxyTLV
+     *
+     * @param typeByteValue the byteValue of the TLV. This is especially important if non-standard TLVs are used
+     * @param content the raw content of the TLV
+     */
+    public HAProxyTLV(final byte typeByteValue, final ByteBuf content) {
+        this(Type.typeForByteValue(typeByteValue), typeByteValue, content);
+    }
+
+    /**
+     * Creates a new HAProxyTLV
+     *
+     * @param type the {@link Type} of the TLV
+     * @param content the raw content of the TLV
+     */
+    public HAProxyTLV(Type type, final ByteBuf content) {
+        this(type, Type.byteValueForType(type), content);
     }
 
     /**
@@ -145,5 +197,16 @@ public class HAProxyTLV extends DefaultByteBufHolder {
     public HAProxyTLV touch(Object hint) {
         super.touch(hint);
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(256)
+                .append(StringUtil.simpleClassName(this))
+                .append("(type: ").append(type)
+                .append(", typeByteValue: ").append(typeByteValue)
+                .append(", content: ").append(contentToString())
+                .append(')')
+                .toString();
     }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -88,7 +88,14 @@ public class HAProxyTLV extends DefaultByteBufHolder {
             }
         }
 
-        public static byte byteValueForType(final Type type) {
+        /**
+         * Returns the byte value for the {@link Type} as defined in the PROXY protocol 1.5 spec.
+         *
+         * @param type the {@link Type}
+         *
+         * @return the byte value of the {@link Type}.
+         */
+        public static byte byteValueForType(Type type) {
             switch (type) {
             case PP2_TYPE_ALPN:
                 return 0x01;
@@ -201,12 +208,9 @@ public class HAProxyTLV extends DefaultByteBufHolder {
 
     @Override
     public String toString() {
-        return new StringBuilder(256)
-                .append(StringUtil.simpleClassName(this))
-                .append("(type: ").append(type)
-                .append(", typeByteValue: ").append(typeByteValue)
-                .append(", content: ").append(contentToString())
-                .append(')')
-                .toString();
+        return StringUtil.simpleClassName(this) +
+               "(type: " + type() +
+               ", typeByteValue: " + typeByteValue() +
+               ", content: " + contentToString() + ')';
     }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -69,7 +69,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
          *
          * @return the {@link Type} of a TLV
          */
-        public static Type typeForByteValue(final byte byteValue) {
+        public static Type typeForByteValue(byte byteValue) {
             switch (byteValue) {
             case 0x01:
                 return PP2_TYPE_ALPN;
@@ -121,7 +121,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
      * @param typeByteValue the byteValue of the TLV. This is especially important if non-standard TLVs are used
      * @param content the raw content of the TLV
      */
-    public HAProxyTLV(final byte typeByteValue, final ByteBuf content) {
+    public HAProxyTLV(byte typeByteValue, ByteBuf content) {
         this(Type.typeForByteValue(typeByteValue), typeByteValue, content);
     }
 
@@ -131,7 +131,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
      * @param type the {@link Type} of the TLV
      * @param content the raw content of the TLV
      */
-    public HAProxyTLV(Type type, final ByteBuf content) {
+    public HAProxyTLV(Type type, ByteBuf content) {
         this(type, Type.byteValueForType(type), content);
     }
 

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class HAProxyIntegrationTest {
+
+    @Test
+    public void testBasicCase() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<HAProxyMessage> msgHolder = new AtomicReference<HAProxyMessage>();
+
+        EventLoopGroup group = new DefaultEventLoopGroup();
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.channel(LocalServerChannel.class)
+          .group(group)
+          .childHandler(new ChannelInitializer() {
+              @Override
+              protected void initChannel(Channel ch) throws Exception {
+                  ch.pipeline().addLast(new HAProxyMessageDecoder());
+                  ch.pipeline().addLast(new SimpleChannelInboundHandler<HAProxyMessage>() {
+                      @Override
+                      protected void channelRead0(ChannelHandlerContext ctx, HAProxyMessage msg) throws Exception {
+                          msgHolder.set(msg);
+                          latch.countDown();
+                      }
+                  });
+              }
+          });
+
+        LocalAddress localAddress = new LocalAddress("HAProxyIntegrationTest");
+        sb.bind(localAddress).sync().channel();
+
+        Bootstrap b = new Bootstrap();
+        Channel clientChannel = b.channel(LocalChannel.class)
+                                 .handler(new HAProxyMessageEncoder())
+                                 .group(group)
+                                 .connect(localAddress).sync().channel();
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443);
+        clientChannel.writeAndFlush(message);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        HAProxyMessage readMessage = msgHolder.get();
+
+        assertEquals(message.protocolVersion(), readMessage.protocolVersion());
+        assertEquals(message.command(), readMessage.command());
+        assertEquals(message.proxiedProtocol(), readMessage.proxiedProtocol());
+        assertEquals(message.sourceAddress(), readMessage.sourceAddress());
+        assertEquals(message.destinationAddress(), readMessage.destinationAddress());
+        assertEquals(message.sourcePort(), readMessage.sourcePort());
+        assertEquals(message.destinationPort(), readMessage.destinationPort());
+    }
+
+}

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -92,5 +92,4 @@ public class HAProxyIntegrationTest {
             group.shutdownGracefully().sync();
         }
     }
-
 }

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+import static io.netty.handler.codec.haproxy.HAProxyMessageEncoder.*;
 import static org.junit.Assert.*;
 
 public class HaProxyMessageEncoderTest {
@@ -37,12 +38,10 @@ public class HaProxyMessageEncoderTest {
     private static final int V2_HEADER_BYTES_LENGTH = 16;
     private static final int IPv4_ADDRESS_BYTES_LENGTH = 12;
     private static final int IPv6_ADDRESS_BYTES_LENGTH = 36;
-    private static final int UNIX_ADDRESS_BYTES_LENGTH = 216;
 
     @Test
     public void testIPV4EncodeProxyV1() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
@@ -53,12 +52,14 @@ public class HaProxyMessageEncoderTest {
 
         assertEquals("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n",
                      byteBuf.toString(CharsetUtil.US_ASCII));
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testIPV6EncodeProxyV1() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
@@ -69,12 +70,14 @@ public class HaProxyMessageEncoderTest {
 
         assertEquals("PROXY TCP6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n",
                      byteBuf.toString(CharsetUtil.US_ASCII));
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testIPv4EncodeProxyV2() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
@@ -103,11 +106,11 @@ public class HaProxyMessageEncoderTest {
 
         // source address
         byte[] sourceAddr = ByteBufUtil.getBytes(byteBuf, 16, 4);
-        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x01}, sourceAddr);
+        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x01 }, sourceAddr);
 
         // destination address
         byte[] destAddr = ByteBufUtil.getBytes(byteBuf, 20, 4);
-        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x0b}, destAddr);
+        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x0b }, destAddr);
 
         // source port
         int sourcePort = byteBuf.getUnsignedShort(24);
@@ -116,12 +119,14 @@ public class HaProxyMessageEncoderTest {
         // destination port
         int destPort = byteBuf.getUnsignedShort(26);
         assertEquals(443, destPort);
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testIPv6EncodeProxyV2() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
@@ -150,14 +155,18 @@ public class HaProxyMessageEncoderTest {
 
         // source address
         byte[] sourceAddr = ByteBufUtil.getBytes(byteBuf, 16, 16);
-        assertArrayEquals(new byte[] { (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8,
+        assertArrayEquals(new byte[] {
+                (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8,
                 (byte) 0x85, (byte) 0xa3, 0x00, 0x00, 0x00, 0x00, (byte) 0x8a, 0x2e,
-                0x03, 0x70, 0x73, 0x34}, sourceAddr);
+                0x03, 0x70, 0x73, 0x34
+        }, sourceAddr);
 
         // destination address
         byte[] destAddr = ByteBufUtil.getBytes(byteBuf, 32, 16);
-        assertArrayEquals(new byte[] { (byte) 0x10, (byte) 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x05, 0x06, 0x00, 0x30, 0x0c, 0x32, 0x6b}, destAddr);
+        assertArrayEquals(new byte[] {
+                (byte) 0x10, (byte) 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x05, 0x06, 0x00, 0x30, 0x0c, 0x32, 0x6b
+        }, destAddr);
 
         // source port
         int sourcePort = byteBuf.getUnsignedShort(48);
@@ -166,12 +175,14 @@ public class HaProxyMessageEncoderTest {
         // destination port
         int destPort = byteBuf.getUnsignedShort(50);
         assertEquals(443, destPort);
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testUnixEncodeProxyV2() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
@@ -194,9 +205,9 @@ public class HaProxyMessageEncoderTest {
         assertEquals(0x03, (transportByte & 0xf0) >> 4);
         assertEquals(0x01, transportByte & 0x0f);
 
-        // source address length
-        int sourceAddrLength = byteBuf.getUnsignedShort(14);
-        assertEquals(216, sourceAddrLength);
+        // address length
+        int addrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(TOTAL_UNIX_ADDRESS_BYTES_LENGTH, addrLength);
 
         // source address
         int srcAddrEnd = byteBuf.forEachByte(16, 108, ByteProcessor.FIND_NUL);
@@ -207,12 +218,14 @@ public class HaProxyMessageEncoderTest {
         int dstAddrEnd = byteBuf.forEachByte(124, 108, ByteProcessor.FIND_NUL);
         assertEquals("/var/run/dst.sock",
                      byteBuf.slice(124, dstAddrEnd - 124).toString(CharsetUtil.US_ASCII));
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testTLVEncodeProxy() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
 
@@ -248,12 +261,14 @@ public class HaProxyMessageEncoderTest {
         bufLength = tlv.readShort();
         assertEquals(arbitrary.array().length, bufLength);
         assertEquals(arbitrary, tlv.readBytes(bufLength));
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testSslTLVEncodeProxy() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
 
@@ -301,12 +316,14 @@ public class HaProxyMessageEncoderTest {
         bufLength = tlv.readShort();
         assertEquals(arbitrary.array().length, bufLength);
         assertEquals(arbitrary, tlv.readBytes(bufLength));
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
     @Test
     public void testEncodeLocalProxyV2() {
-        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+        EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.LOCAL, HAProxyProxiedProtocol.UNKNOWN,
@@ -334,9 +351,12 @@ public class HaProxyMessageEncoderTest {
         assertEquals(0, sourceAddrLength);
 
         assertFalse(byteBuf.isReadable());
+
+        byteBuf.release();
+        assertFalse(ch.finish());
     }
 
-    @Test(expected = HAProxyProtocolException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidIpV4Address() {
         String invalidIpv4Address = "192.168.0.1234";
         new HAProxyMessage(
@@ -344,7 +364,7 @@ public class HaProxyMessageEncoderTest {
                 invalidIpv4Address, "192.168.0.11", 56324, 443);
     }
 
-    @Test(expected = HAProxyProtocolException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidIpV6Address() {
         String invalidIpv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:73345";
         new HAProxyMessage(
@@ -352,7 +372,7 @@ public class HaProxyMessageEncoderTest {
                 invalidIpv6Address, "1050:0:0:0:5:600:300c:326b", 56324, 443);
     }
 
-    @Test(expected = HAProxyProtocolException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidUnixAddress() {
         String invalidUnixAddress = new String(new byte[UNIX_ADDRESS_BYTES_LENGTH + 1]);
         new HAProxyMessage(
@@ -360,14 +380,14 @@ public class HaProxyMessageEncoderTest {
                 invalidUnixAddress, "/var/run/dst.sock", 0, 0);
     }
 
-    @Test(expected = HAProxyProtocolException.class)
+    @Test(expected = NullPointerException.class)
     public void testNullUnixAddress() {
         new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
                 null, null, 0, 0);
     }
 
-    @Test(expected = HAProxyProtocolException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testLongUnixAddress() {
         String longUnixAddress = new String(new char[109]).replace("\0", "a");
         new HAProxyMessage(
@@ -375,7 +395,7 @@ public class HaProxyMessageEncoderTest {
                 "source", longUnixAddress, 0, 0);
     }
 
-    @Test(expected = HAProxyProtocolException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidUnixPort() {
         new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.haproxy.HAProxyTLV.Type;
+import io.netty.util.ByteProcessor;
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+import static org.junit.Assert.*;
+
+public class HaProxyMessageEncoderTest {
+
+    private static final int V2_HEADER_BYTES_LENGTH = 16;
+    private static final int IPv4_ADDRESS_BYTES_LENGTH = 12;
+    private static final int IPv6_ADDRESS_BYTES_LENGTH = 36;
+    private static final int UNIX_ADDRESS_BYTES_LENGTH = 216;
+
+    @Test
+    public void testIPV4EncodeProxyV1() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        assertEquals("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n",
+                     byteBuf.toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testIPV6EncodeProxyV1() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1050:0:0:0:5:600:300c:326b", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        assertEquals("PROXY TCP6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n",
+                     byteBuf.toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testIPv4EncodeProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = ByteBufUtil.getBytes(byteBuf, 0, 12);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.getByte(12);
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x01, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.getByte(13);
+        assertEquals(0x01, (transportByte & 0xf0) >> 4);
+        assertEquals(0x01, transportByte & 0x0f);
+
+        // source address length
+        int sourceAddrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(12, sourceAddrLength);
+
+        // source address
+        byte[] sourceAddr = ByteBufUtil.getBytes(byteBuf, 16, 4);
+        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x01}, sourceAddr);
+
+        // destination address
+        byte[] destAddr = ByteBufUtil.getBytes(byteBuf, 20, 4);
+        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x0b}, destAddr);
+
+        // source port
+        int sourcePort = byteBuf.getUnsignedShort(24);
+        assertEquals(56324, sourcePort);
+
+        // destination port
+        int destPort = byteBuf.getUnsignedShort(26);
+        assertEquals(443, destPort);
+    }
+
+    @Test
+    public void testIPv6EncodeProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1050:0:0:0:5:600:300c:326b", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = ByteBufUtil.getBytes(byteBuf, 0, 12);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.getByte(12);
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x01, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.getByte(13);
+        assertEquals(0x02, (transportByte & 0xf0) >> 4);
+        assertEquals(0x01, transportByte & 0x0f);
+
+        // source address length
+        int sourceAddrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(IPv6_ADDRESS_BYTES_LENGTH, sourceAddrLength);
+
+        // source address
+        byte[] sourceAddr = ByteBufUtil.getBytes(byteBuf, 16, 16);
+        assertArrayEquals(new byte[] { (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8,
+                (byte) 0x85, (byte) 0xa3, 0x00, 0x00, 0x00, 0x00, (byte) 0x8a, 0x2e,
+                0x03, 0x70, 0x73, 0x34}, sourceAddr);
+
+        // destination address
+        byte[] destAddr = ByteBufUtil.getBytes(byteBuf, 32, 16);
+        assertArrayEquals(new byte[] { (byte) 0x10, (byte) 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x05, 0x06, 0x00, 0x30, 0x0c, 0x32, 0x6b}, destAddr);
+
+        // source port
+        int sourcePort = byteBuf.getUnsignedShort(48);
+        assertEquals(56324, sourcePort);
+
+        // destination port
+        int destPort = byteBuf.getUnsignedShort(50);
+        assertEquals(443, destPort);
+    }
+
+    @Test
+    public void testUnixEncodeProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                "/var/run/src.sock", "/var/run/dst.sock", 0, 0);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = ByteBufUtil.getBytes(byteBuf, 0, 12);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.getByte(12);
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x01, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.getByte(13);
+        assertEquals(0x03, (transportByte & 0xf0) >> 4);
+        assertEquals(0x01, transportByte & 0x0f);
+
+        // source address length
+        int sourceAddrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(216, sourceAddrLength);
+
+        // source address
+        int srcAddrEnd = byteBuf.forEachByte(16, 108, ByteProcessor.FIND_NUL);
+        assertEquals("/var/run/src.sock",
+                     byteBuf.slice(16, srcAddrEnd - 16).toString(CharsetUtil.US_ASCII));
+
+        // destination address
+        int dstAddrEnd = byteBuf.forEachByte(124, 108, ByteProcessor.FIND_NUL);
+        assertEquals("/var/run/dst.sock",
+                     byteBuf.slice(124, dstAddrEnd - 124).toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testTLVEncodeProxy() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
+
+        ByteBuf helloWorld = Unpooled.copiedBuffer("hello world", CharsetUtil.US_ASCII);
+        HAProxyTLV alpnTlv = new HAProxyTLV(Type.PP2_TYPE_ALPN, (byte) 0x01, helloWorld.copy());
+        tlvs.add(alpnTlv);
+
+        ByteBuf arbitrary = Unpooled.copiedBuffer("an arbitrary string", CharsetUtil.US_ASCII);
+        HAProxyTLV authorityTlv = new HAProxyTLV(Type.PP2_TYPE_AUTHORITY, (byte) 0x01, arbitrary.copy());
+        tlvs.add(authorityTlv);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443, tlvs);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // length
+        assertEquals(byteBuf.getUnsignedShort(14), byteBuf.readableBytes() - V2_HEADER_BYTES_LENGTH);
+
+        // skip to tlv section
+        ByteBuf tlv = byteBuf.skipBytes(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
+
+        // alpn tlv
+        assertEquals(alpnTlv.typeByteValue(), tlv.readByte());
+        short bufLength = tlv.readShort();
+        assertEquals(helloWorld.array().length, bufLength);
+        assertEquals(helloWorld, tlv.readBytes(bufLength));
+
+        // authority tlv
+        assertEquals(authorityTlv.typeByteValue(), tlv.readByte());
+        bufLength = tlv.readShort();
+        assertEquals(arbitrary.array().length, bufLength);
+        assertEquals(arbitrary, tlv.readBytes(bufLength));
+    }
+
+    @Test
+    public void testSslTLVEncodeProxy() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
+
+        ByteBuf helloWorld = Unpooled.copiedBuffer("hello world", CharsetUtil.US_ASCII);
+        HAProxyTLV alpnTlv = new HAProxyTLV(Type.PP2_TYPE_ALPN, (byte) 0x01, helloWorld.copy());
+        tlvs.add(alpnTlv);
+
+        ByteBuf arbitrary = Unpooled.copiedBuffer("an arbitrary string", CharsetUtil.US_ASCII);
+        HAProxyTLV authorityTlv = new HAProxyTLV(Type.PP2_TYPE_AUTHORITY, (byte) 0x01, arbitrary.copy());
+        tlvs.add(authorityTlv);
+
+        ByteBuf sslContent = Unpooled.copiedBuffer("some ssl content", CharsetUtil.US_ASCII);
+        HAProxySSLTLV haProxySSLTLV = new HAProxySSLTLV(1, (byte) 0x01, tlvs, sslContent.copy());
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443,
+                Collections.<HAProxyTLV>singletonList(haProxySSLTLV));
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        assertEquals(byteBuf.getUnsignedShort(14), byteBuf.readableBytes() - V2_HEADER_BYTES_LENGTH);
+        ByteBuf tlv = byteBuf.skipBytes(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
+
+        // ssl tlv type
+        assertEquals(haProxySSLTLV.typeByteValue(), tlv.readByte());
+
+        // length
+        int bufLength = tlv.readUnsignedShort();
+        assertEquals(bufLength, tlv.readableBytes());
+
+        // client, verify
+        assertEquals(0x01, byteBuf.readByte());
+        assertEquals(1, byteBuf.readInt());
+
+        // alpn tlv
+        assertEquals(alpnTlv.typeByteValue(), tlv.readByte());
+        bufLength = tlv.readShort();
+        assertEquals(helloWorld.array().length, bufLength);
+        assertEquals(helloWorld, tlv.readBytes(bufLength));
+
+        // authority tlv
+        assertEquals(authorityTlv.typeByteValue(), tlv.readByte());
+        bufLength = tlv.readShort();
+        assertEquals(arbitrary.array().length, bufLength);
+        assertEquals(arbitrary, tlv.readBytes(bufLength));
+    }
+
+    @Test
+    public void testEncodeLocalProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.LOCAL, HAProxyProxiedProtocol.UNKNOWN,
+                null, null, 0, 0);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = new byte[12];
+        byteBuf.readBytes(headerBytes);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.readByte();
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x00, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.readByte();
+        assertEquals(0x00, transportByte);
+
+        // source address length
+        int sourceAddrLength = byteBuf.readUnsignedShort();
+        assertEquals(0, sourceAddrLength);
+
+        assertFalse(byteBuf.isReadable());
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidIpV4Address() {
+        String invalidIpv4Address = "192.168.0.1234";
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                invalidIpv4Address, "192.168.0.11", 56324, 443);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidIpV6Address() {
+        String invalidIpv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:73345";
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
+                invalidIpv6Address, "1050:0:0:0:5:600:300c:326b", 56324, 443);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidUnixAddress() {
+        String invalidUnixAddress = new String(new byte[UNIX_ADDRESS_BYTES_LENGTH + 1]);
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                invalidUnixAddress, "/var/run/dst.sock", 0, 0);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testNullUnixAddress() {
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                null, null, 0, 0);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testLongUnixAddress() {
+        String longUnixAddress = new String(new char[109]).replace("\0", "a");
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                "source", longUnixAddress, 0, 0);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidUnixPort() {
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                "/var/run/src.sock", "/var/run/dst.sock", 80, 443);
+    }
+}

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>netty-codec-mqtt</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.haproxy;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyCommand;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import io.netty.util.CharsetUtil;
+
+import static io.netty.example.haproxy.HAProxyServer.*;
+
+public final class HAProxyClient {
+
+    private static final String HOST = System.getProperty("host", "127.0.0.1");
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup group = new NioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+             .channel(NioSocketChannel.class)
+             .handler(new HAProxyHandler());
+
+            // Start the connection attempt.
+            Channel ch = b.connect(HOST, PORT).sync().channel();
+
+            HAProxyMessage message = new HAProxyMessage(
+                    HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                    "127.0.0.1", "127.0.0.2", 8000, 9000);
+
+            ch.writeAndFlush(message).sync();
+            ch.writeAndFlush(Unpooled.copiedBuffer("Hello World!", CharsetUtil.US_ASCII)).sync();
+            ch.writeAndFlush(Unpooled.copiedBuffer("Bye now!", CharsetUtil.US_ASCII)).sync();
+            ch.close().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.haproxy;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyMessageEncoder;
+import io.netty.handler.codec.haproxy.HAProxyProtocolException;
+
+public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
+
+    private static final HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        ctx.pipeline().addBefore(ctx.name(), null, encoder);
+        super.handlerAdded(ctx);
+    }
+
+    @Override
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (!(msg instanceof HAProxyMessage)) {
+            super.write(ctx, msg, promise);
+            return;
+        }
+
+        ctx.writeAndFlush(msg, promise).addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                if (future.isSuccess()) {
+                    ctx.pipeline().remove(encoder);
+                    ctx.pipeline().remove(HAProxyHandler.this);
+                } else {
+                    throw new HAProxyProtocolException("failed to write HAProxy message");
+                }
+            }
+        });
+    }
+}

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -40,14 +40,16 @@ public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
             return;
         }
 
-        ctx.writeAndFlush(msg, promise).addListener(new ChannelFutureListener() {
+        ctx.write(msg, promise).addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (future.isSuccess()) {
                     ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
                     ctx.pipeline().remove(HAProxyHandler.this);
                 } else {
-                    throw new HAProxyProtocolException("failed to write HAProxy message");
+                    ctx.fireExceptionCaught(new HAProxyProtocolException("failed to write HAProxy message",
+                                                                         future.cause()));
+                    ctx.close();
                 }
             }
         });

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -27,11 +27,9 @@ import io.netty.handler.codec.haproxy.HAProxyProtocolException;
 
 public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
 
-    private static final HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
-
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        ctx.pipeline().addBefore(ctx.name(), null, encoder);
+        ctx.pipeline().addBefore(ctx.name(), null, HAProxyMessageEncoder.INSTANCE);
         super.handlerAdded(ctx);
     }
 
@@ -46,7 +44,7 @@ public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (future.isSuccess()) {
-                    ctx.pipeline().remove(encoder);
+                    ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
                     ctx.pipeline().remove(HAProxyHandler.this);
                 } else {
                     throw new HAProxyProtocolException("failed to write HAProxy message");

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.haproxy;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+public final class HAProxyServer {
+
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+             .channel(NioServerSocketChannel.class)
+             .handler(new LoggingHandler(LogLevel.INFO))
+             .childHandler(new HAProxyServerInitializer());
+            b.bind(PORT).sync().channel().closeFuture().sync();
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+
+    static class HAProxyServerInitializer extends ChannelInitializer<SocketChannel> {
+        @Override
+        public void initChannel(SocketChannel ch) throws Exception {
+            ch.pipeline().addLast(
+                    new LoggingHandler(LogLevel.DEBUG),
+                    new HAProxyMessageDecoder(),
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                            if (msg instanceof HAProxyMessage) {
+                                System.out.println("proxy message: " + msg);
+                            } else if (msg instanceof ByteBuf) {
+                                System.out.println("bytebuf message: " + ByteBufUtil.prettyHexDump((ByteBuf) msg));
+                            }
+                            super.channelRead(ctx, msg);
+                        }
+                    });
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
@@ -20,9 +20,9 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -57,15 +57,14 @@ public final class HAProxyServer {
             ch.pipeline().addLast(
                     new LoggingHandler(LogLevel.DEBUG),
                     new HAProxyMessageDecoder(),
-                    new ChannelInboundHandlerAdapter() {
+                    new SimpleChannelInboundHandler() {
                         @Override
-                        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                        protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
                             if (msg instanceof HAProxyMessage) {
                                 System.out.println("proxy message: " + msg);
                             } else if (msg instanceof ByteBuf) {
                                 System.out.println("bytebuf message: " + ByteBufUtil.prettyHexDump((ByteBuf) msg));
                             }
-                            super.channelRead(ctx, msg);
                         }
                     });
         }


### PR DESCRIPTION
Motivation:

Add support for HAProxyMessageEncoder

Modification:

- Create public constructors for `HAProxyMessage`, `HAProxySSLTLV`, `HAProxyTLV`.
- Add validations for `UNIX`, `UNSPEC` address, port (both should be backwards compatible)
- Add `toString` implementations for `HAProxyMessage`, `HAProxySSLTLV`, `HAProxyTLV`.
- Add relevant unit tests, integration tests, examples

Result:

Users may now create a HAProxy client-side implementation.
