### PR TITLE
Add support for HAProxyHandler

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyConstants.java
@@ -56,5 +56,23 @@ final class HAProxyConstants {
     static final byte TPAF_UNIX_STREAM_BYTE = 0x31;
     static final byte TPAF_UNIX_DGRAM_BYTE = 0x32;
 
+    /**
+     * V2 protocol binary header prefix
+     */
+    static final byte[] BINARY_PREFIX = {
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x00,
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x51,
+            (byte) 0x55,
+            (byte) 0x49,
+            (byte) 0x54,
+            (byte) 0x0A
+    };
+
     private HAProxyConstants() { }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -23,6 +23,8 @@ import io.netty.util.CharsetUtil;
 
 import java.util.List;
 
+import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+
 /**
  * Decodes an HAProxy proxy protocol header
  *
@@ -48,24 +50,6 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
      * Maximum possible length for v2 additional TLV data (max unsigned short - max v2 address info space)
      */
     private static final int V2_MAX_TLV = 65535 - 216;
-
-    /**
-     * Binary header prefix
-     */
-    private static final byte[] BINARY_PREFIX = {
-            (byte) 0x0D,
-            (byte) 0x0A,
-            (byte) 0x0D,
-            (byte) 0x0A,
-            (byte) 0x00,
-            (byte) 0x0D,
-            (byte) 0x0A,
-            (byte) 0x51,
-            (byte) 0x55,
-            (byte) 0x49,
-            (byte) 0x54,
-            (byte) 0x0A
-    };
 
     private static final byte[] TEXT_PREFIX = {
             (byte) 'P',

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+
+import java.util.List;
+
+import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+
+/**
+ * Encodes an HAProxy proxy protocol header
+ *
+ * @see <a href="http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
+ */
+@Sharable
+public class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMessage> {
+
+    static final int IPv4_ADDRESS_BYTES_LENGTH = 12;
+    static final int IPv6_ADDRESS_BYTES_LENGTH = 36;
+    static final int UNIX_ADDRESS_BYTES_LENGTH = 216;
+
+    private static final int V2_VERSION_BITMASK = 0x02 << 4;
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, HAProxyMessage msg, ByteBuf out) throws Exception {
+        if (msg.protocolVersion() == HAProxyProtocolVersion.V1) {
+            encodeV1(msg, out);
+        } else if (msg.protocolVersion() == HAProxyProtocolVersion.V2) {
+            encodeV2(msg, out);
+        } else {
+            throw new HAProxyProtocolException("Unsupported version: " + msg.protocolVersion());
+        }
+    }
+
+    private static void encodeV1(HAProxyMessage msg, ByteBuf out) {
+        final String protocol = msg.proxiedProtocol().name();
+        StringBuilder sb = new StringBuilder(108)
+                .append("PROXY ").append(protocol).append(' ')
+                .append(msg.sourceAddress()).append(' ')
+                .append(msg.destinationAddress()).append(' ')
+                .append(msg.sourcePort()).append(' ').append(msg.destinationPort()).append("\r\n");
+        out.writeBytes(sb.toString().getBytes(CharsetUtil.US_ASCII));
+    }
+
+    private static void encodeV2(HAProxyMessage msg, ByteBuf out) {
+        out.writeBytes(BINARY_PREFIX);
+        out.writeByte(V2_VERSION_BITMASK | msg.command().byteValue());
+        out.writeByte(msg.proxiedProtocol().byteValue());
+
+        if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_IPv4) {
+            out.writeShort(IPv4_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes());
+            out.writeBytes(NetUtil.createByteArrayFromIpAddressString(msg.sourceAddress()));
+            out.writeBytes(NetUtil.createByteArrayFromIpAddressString(msg.destinationAddress()));
+            out.writeShort(msg.sourcePort());
+            out.writeShort(msg.destinationPort());
+            encodeTlvs(msg.tlvs(), out);
+        } else if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_IPv6) {
+            out.writeShort(IPv6_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes());
+            out.writeBytes(NetUtil.getByName(msg.sourceAddress()).getAddress());
+            out.writeBytes(NetUtil.getByName(msg.destinationAddress()).getAddress());
+            out.writeShort(msg.sourcePort());
+            out.writeShort(msg.destinationPort());
+            encodeTlvs(msg.tlvs(), out);
+        } else if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_UNIX) {
+            out.writeShort(UNIX_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes());
+            byte[] srcAddressBytes = msg.sourceAddress().getBytes(CharsetUtil.US_ASCII);
+            out.writeBytes(srcAddressBytes);
+            out.writeBytes(new byte[108 - srcAddressBytes.length]);
+            byte[] dstAddressBytes = msg.destinationAddress().getBytes(CharsetUtil.US_ASCII);
+            out.writeBytes(dstAddressBytes);
+            out.writeBytes(new byte[108 - dstAddressBytes.length]);
+            encodeTlvs(msg.tlvs(), out);
+        } else if (msg.proxiedProtocol().addressFamily() == AddressFamily.AF_UNSPEC) {
+            out.writeShort(0);
+        }
+    }
+
+    private static void encodeTlv(HAProxyTLV haProxyTLV, ByteBuf out) {
+        if (haProxyTLV instanceof HAProxySSLTLV) {
+            HAProxySSLTLV ssltlv = (HAProxySSLTLV) haProxyTLV;
+            out.writeByte(haProxyTLV.typeByteValue());
+            out.writeShort(ssltlv.contentNumBytes());
+            out.writeByte(ssltlv.client());
+            out.writeInt(ssltlv.verify());
+            encodeTlvs(ssltlv.encapsulatedTLVs(), out);
+        } else {
+            out.writeByte(haProxyTLV.typeByteValue());
+            ByteBuf value = haProxyTLV.content();
+            int readableBytes = value.readableBytes();
+            out.writeShort(readableBytes);
+            out.writeBytes(value.readSlice(readableBytes));
+        }
+    }
+
+    private static void encodeTlvs(List<HAProxyTLV> haProxyTLVs, ByteBuf out) {
+        for (HAProxyTLV tlv: haProxyTLVs) {
+            encodeTlv(tlv, out);
+        }
+    }
+}

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
@@ -17,6 +17,8 @@
 package io.netty.handler.codec.haproxy;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.internal.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +37,19 @@ public final class HAProxySSLTLV extends HAProxyTLV {
      * Creates a new HAProxySSLTLV
      *
      * @param verify the verification result as defined in the specification for the pp2_tlv_ssl struct (see
-     * http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)
+     * http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+     * @param clientBitField the bitfield with client information
+     * @param tlvs the encapsulated {@link HAProxyTLV}s
+     */
+    public HAProxySSLTLV(final int verify, final byte clientBitField, final List<HAProxyTLV> tlvs) {
+        this(verify, clientBitField, tlvs, Unpooled.EMPTY_BUFFER);
+    }
+
+    /**
+     * Creates a new HAProxySSLTLV
+     *
+     * @param verify the verification result as defined in the specification for the pp2_tlv_ssl struct (see
+     * http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
      * @param clientBitField the bitfield with client information
      * @param tlvs the encapsulated {@link HAProxyTLV}s
      * @param rawContent the raw TLV content
@@ -69,6 +83,9 @@ public final class HAProxySSLTLV extends HAProxyTLV {
         return (clientBitField & 0x4) != 0;
     }
 
+    public byte client() {
+        return clientBitField;
+    }
     /**
      * Returns the verification result
      */
@@ -83,4 +100,42 @@ public final class HAProxySSLTLV extends HAProxyTLV {
         return tlvs;
     }
 
+    @Override
+    int contentNumBytes() {
+        int tlvNumBytes = 0;
+        for (int i = 0; i < tlvs.size(); i++) {
+            tlvNumBytes += tlvs.get(i).totalNumBytes();
+        }
+        return 5 + tlvNumBytes; // clientBit(1) + verify(4) + tlvs
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(128)
+                .append(StringUtil.simpleClassName(this))
+                .append("(type: ").append(type())
+                .append(", typeByteValue: ").append(typeByteValue())
+                .append(", client: ").append(client())
+                .append(", verify: ").append(verify())
+                .append(", encapsulatedTlvs: [");
+        for (HAProxyTLV tlv: tlvs) {
+            sb.append(tlv).append(", ");
+        }
+        if (!tlvs.isEmpty()) {
+            sb.setLength(sb.length() - 2);
+        }
+        sb.append("])");
+        return sb.toString();
+    }
+
+    @Override
+    String simpleToString() {
+        return new StringBuilder(128)
+                .append(StringUtil.simpleClassName(this))
+                .append("(type: ").append(type())
+                .append(", typeByteValue: ").append(typeByteValue())
+                .append(", client: ").append(client())
+                .append(", verify: ").append(verify())
+                .append(')').toString();
+    }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.haproxy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.util.internal.StringUtil;
 
 import static io.netty.util.internal.ObjectUtil.*;
 
@@ -31,6 +32,18 @@ public class HAProxyTLV extends DefaultByteBufHolder {
 
     private final Type type;
     private final byte typeByteValue;
+
+    /**
+     * The size of this tlv in bytes.
+     * @return the number of bytes.
+     */
+    int totalNumBytes() {
+        return 3 + contentNumBytes(); // type(1) + length(2) + content
+    }
+
+    int contentNumBytes() {
+        return content().readableBytes();
+    }
 
     /**
      * The registered types a TLV can have regarding the PROXY protocol 1.5 spec
@@ -74,6 +87,45 @@ public class HAProxyTLV extends DefaultByteBufHolder {
                 return OTHER;
             }
         }
+
+        public static byte byteValueForType(final Type type) {
+            switch (type) {
+            case PP2_TYPE_ALPN:
+                return 0x01;
+            case PP2_TYPE_AUTHORITY:
+                return 0x02;
+            case PP2_TYPE_SSL:
+                return 0x20;
+            case PP2_TYPE_SSL_VERSION:
+                return 0x21;
+            case PP2_TYPE_SSL_CN:
+                return 0x22;
+            case PP2_TYPE_NETNS:
+                return 0x30;
+            default:
+                throw new IllegalArgumentException("unknown type: " + type);
+            }
+        }
+    }
+
+    /**
+     * Creates a new HAProxyTLV
+     *
+     * @param typeByteValue the byteValue of the TLV. This is especially important if non-standard TLVs are used
+     * @param content the raw content of the TLV
+     */
+    public HAProxyTLV(final byte typeByteValue, final ByteBuf content) {
+        this(Type.typeForByteValue(typeByteValue), typeByteValue, content);
+    }
+
+    /**
+     * Creates a new HAProxyTLV
+     *
+     * @param type the {@link Type} of the TLV
+     * @param content the raw content of the TLV
+     */
+    public HAProxyTLV(Type type, final ByteBuf content) {
+        this(type, Type.byteValueForType(type), content);
     }
 
     /**
@@ -145,5 +197,24 @@ public class HAProxyTLV extends DefaultByteBufHolder {
     public HAProxyTLV touch(Object hint) {
         super.touch(hint);
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(256)
+                .append(StringUtil.simpleClassName(this))
+                .append("(type: ").append(type)
+                .append(", typeByteValue: ").append(typeByteValue)
+                .append(", content: ").append(contentToString())
+                .append(')')
+                .toString();
+    }
+
+    String simpleToString() {
+        return new StringBuilder(64)
+                .append(StringUtil.simpleClassName(this))
+                .append("(type: ").append(type)
+                .append(", typeByteValue: ").append(typeByteValue)
+                .append(')').toString();
     }
 }

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class HAProxyIntegrationTest {
+
+    @Test
+    public void testBasicCase() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<HAProxyMessage> msgHolder = new AtomicReference<HAProxyMessage>();
+
+        EventLoopGroup group = new DefaultEventLoopGroup();
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.channel(LocalServerChannel.class)
+          .group(group)
+          .childHandler(new ChannelInitializer() {
+              @Override
+              protected void initChannel(Channel ch) throws Exception {
+                  ch.pipeline().addLast(new HAProxyMessageDecoder());
+                  ch.pipeline().addLast(new SimpleChannelInboundHandler<HAProxyMessage>() {
+                      @Override
+                      protected void channelRead0(ChannelHandlerContext ctx, HAProxyMessage msg) throws Exception {
+                          msgHolder.set(msg);
+                          latch.countDown();
+                      }
+                  });
+              }
+          });
+
+        LocalAddress localAddress = new LocalAddress("HAProxyIntegrationTest");
+        sb.bind(localAddress).sync().channel();
+
+        Bootstrap b = new Bootstrap();
+        Channel clientChannel = b.channel(LocalChannel.class)
+                                 .handler(new HAProxyMessageEncoder())
+                                 .group(group)
+                                 .connect(localAddress).sync().channel();
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443);
+        clientChannel.writeAndFlush(message);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        HAProxyMessage readMessage = msgHolder.get();
+
+        assertEquals(message.protocolVersion(), readMessage.protocolVersion());
+        assertEquals(message.command(), readMessage.command());
+        assertEquals(message.proxiedProtocol(), readMessage.proxiedProtocol());
+        assertEquals(message.sourceAddress(), readMessage.sourceAddress());
+        assertEquals(message.destinationAddress(), readMessage.destinationAddress());
+        assertEquals(message.sourcePort(), readMessage.sourcePort());
+        assertEquals(message.destinationPort(), readMessage.destinationPort());
+    }
+
+}

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.haproxy.HAProxyTLV.Type;
+import io.netty.util.ByteProcessor;
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
+import static io.netty.handler.codec.haproxy.HAProxyMessageEncoder.*;
+import static org.junit.Assert.*;
+
+public class HaProxyMessageEncoderTest {
+
+    static final int V2_HEADER_BYTES_LENGTH = 16;
+
+    @Test
+    public void testIPV4EncodeProxyV1() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        assertEquals("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n",
+                     byteBuf.toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testIPV6EncodeProxyV1() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1050:0:0:0:5:600:300c:326b", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        assertEquals("PROXY TCP6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n",
+                     byteBuf.toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testIPv4EncodeProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = ByteBufUtil.getBytes(byteBuf, 0, 12);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.getByte(12);
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x01, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.getByte(13);
+        assertEquals(0x01, (transportByte & 0xf0) >> 4);
+        assertEquals(0x01, transportByte & 0x0f);
+
+        // source address length
+        int sourceAddrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(12, sourceAddrLength);
+
+        // source address
+        byte[] sourceAddr = ByteBufUtil.getBytes(byteBuf, 16, 4);
+        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x01}, sourceAddr);
+
+        // destination address
+        byte[] destAddr = ByteBufUtil.getBytes(byteBuf, 20, 4);
+        assertArrayEquals(new byte[] { (byte) 0xc0, (byte) 0xa8, 0x00, 0x0b}, destAddr);
+
+        // source port
+        int sourcePort = byteBuf.getUnsignedShort(24);
+        assertEquals(56324, sourcePort);
+
+        // destination port
+        int destPort = byteBuf.getUnsignedShort(26);
+        assertEquals(443, destPort);
+    }
+
+    @Test
+    public void testIPv6EncodeProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1050:0:0:0:5:600:300c:326b", 56324, 443);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = ByteBufUtil.getBytes(byteBuf, 0, 12);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.getByte(12);
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x01, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.getByte(13);
+        assertEquals(0x02, (transportByte & 0xf0) >> 4);
+        assertEquals(0x01, transportByte & 0x0f);
+
+        // source address length
+        int sourceAddrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(36, sourceAddrLength);
+
+        // source address
+        byte[] sourceAddr = ByteBufUtil.getBytes(byteBuf, 16, 16);
+        assertArrayEquals(new byte[] { (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8,
+                (byte) 0x85, (byte) 0xa3, 0x00, 0x00, 0x00, 0x00, (byte) 0x8a, 0x2e,
+                0x03, 0x70, 0x73, 0x34}, sourceAddr);
+
+        // destination address
+        byte[] destAddr = ByteBufUtil.getBytes(byteBuf, 32, 16);
+        assertArrayEquals(new byte[] { (byte) 0x10, (byte) 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x05, 0x06, 0x00, 0x30, 0x0c, 0x32, 0x6b}, destAddr);
+
+        // source port
+        int sourcePort = byteBuf.getUnsignedShort(48);
+        assertEquals(56324, sourcePort);
+
+        // destination port
+        int destPort = byteBuf.getUnsignedShort(50);
+        assertEquals(443, destPort);
+    }
+
+    @Test
+    public void testUnixEncodeProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                "/var/run/src.sock", "/var/run/dst.sock", 0, 0);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = ByteBufUtil.getBytes(byteBuf, 0, 12);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.getByte(12);
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x01, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.getByte(13);
+        assertEquals(0x03, (transportByte & 0xf0) >> 4);
+        assertEquals(0x01, transportByte & 0x0f);
+
+        // source address length
+        int sourceAddrLength = byteBuf.getUnsignedShort(14);
+        assertEquals(216, sourceAddrLength);
+
+        // source address
+        int srcAddrEnd = byteBuf.forEachByte(16, 108, ByteProcessor.FIND_NUL);
+        assertEquals("/var/run/src.sock",
+                     byteBuf.slice(16, srcAddrEnd - 16).toString(CharsetUtil.US_ASCII));
+
+        // destination address
+        int dstAddrEnd = byteBuf.forEachByte(124, 108, ByteProcessor.FIND_NUL);
+        assertEquals("/var/run/dst.sock",
+                     byteBuf.slice(124, dstAddrEnd - 124).toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testTLVEncodeProxy() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
+
+        ByteBuf helloWorld = Unpooled.copiedBuffer("hello world", CharsetUtil.US_ASCII);
+        HAProxyTLV alpnTlv = new HAProxyTLV(Type.PP2_TYPE_ALPN, (byte) 0x01, helloWorld.copy());
+        tlvs.add(alpnTlv);
+
+        ByteBuf arbitrary = Unpooled.copiedBuffer("an arbitrary string", CharsetUtil.US_ASCII);
+        HAProxyTLV authorityTlv = new HAProxyTLV(Type.PP2_TYPE_AUTHORITY, (byte) 0x01, arbitrary.copy());
+        tlvs.add(authorityTlv);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443, tlvs);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // length
+        assertEquals(byteBuf.getUnsignedShort(14), byteBuf.readableBytes() - V2_HEADER_BYTES_LENGTH);
+
+        // skip to tlv section
+        ByteBuf tlv = byteBuf.skipBytes(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
+
+        // alpn tlv
+        assertEquals(alpnTlv.typeByteValue(), tlv.readByte());
+        short bufLength = tlv.readShort();
+        assertEquals(helloWorld.array().length, bufLength);
+        assertEquals(helloWorld, tlv.readBytes(bufLength));
+
+        // authority tlv
+        assertEquals(authorityTlv.typeByteValue(), tlv.readByte());
+        bufLength = tlv.readShort();
+        assertEquals(arbitrary.array().length, bufLength);
+        assertEquals(arbitrary, tlv.readBytes(bufLength));
+    }
+
+    @Test
+    public void testSslTLVEncodeProxy() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
+
+        ByteBuf helloWorld = Unpooled.copiedBuffer("hello world", CharsetUtil.US_ASCII);
+        HAProxyTLV alpnTlv = new HAProxyTLV(Type.PP2_TYPE_ALPN, (byte) 0x01, helloWorld.copy());
+        tlvs.add(alpnTlv);
+
+        ByteBuf arbitrary = Unpooled.copiedBuffer("an arbitrary string", CharsetUtil.US_ASCII);
+        HAProxyTLV authorityTlv = new HAProxyTLV(Type.PP2_TYPE_AUTHORITY, (byte) 0x01, arbitrary.copy());
+        tlvs.add(authorityTlv);
+
+        ByteBuf sslContent = Unpooled.copiedBuffer("some ssl content", CharsetUtil.US_ASCII);
+        HAProxySSLTLV haProxySSLTLV = new HAProxySSLTLV(1, (byte) 0x01, tlvs, sslContent.copy());
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "192.168.0.1", "192.168.0.11", 56324, 443,
+                Collections.<HAProxyTLV>singletonList(haProxySSLTLV));
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        assertEquals(byteBuf.getUnsignedShort(14), byteBuf.readableBytes() - V2_HEADER_BYTES_LENGTH);
+        ByteBuf tlv = byteBuf.skipBytes(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
+
+        // ssl tlv type
+        assertEquals(haProxySSLTLV.typeByteValue(), tlv.readByte());
+
+        // length
+        int bufLength = tlv.readUnsignedShort();
+        assertEquals(bufLength, tlv.readableBytes());
+
+        // client, verify
+        assertEquals(0x01, byteBuf.readByte());
+        assertEquals(1, byteBuf.readInt());
+
+        // alpn tlv
+        assertEquals(alpnTlv.typeByteValue(), tlv.readByte());
+        bufLength = tlv.readShort();
+        assertEquals(helloWorld.array().length, bufLength);
+        assertEquals(helloWorld, tlv.readBytes(bufLength));
+
+        // authority tlv
+        assertEquals(authorityTlv.typeByteValue(), tlv.readByte());
+        bufLength = tlv.readShort();
+        assertEquals(arbitrary.array().length, bufLength);
+        assertEquals(arbitrary, tlv.readBytes(bufLength));
+    }
+
+    @Test
+    public void testEncodeLocalProxyV2() {
+        HAProxyMessageEncoder encoder = new HAProxyMessageEncoder();
+        EmbeddedChannel ch = new EmbeddedChannel(encoder);
+
+        HAProxyMessage message = new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.LOCAL, HAProxyProxiedProtocol.UNKNOWN,
+                null, null, 0, 0);
+        assertTrue(ch.writeOutbound(message));
+
+        ByteBuf byteBuf = ch.readOutbound();
+
+        // header
+        byte[] headerBytes = new byte[12];
+        byteBuf.readBytes(headerBytes);
+        assertArrayEquals(BINARY_PREFIX, headerBytes);
+
+        // command
+        byte commandByte = byteBuf.readByte();
+        assertEquals(0x02, (commandByte & 0xf0) >> 4);
+        assertEquals(0x00, commandByte & 0x0f);
+
+        // transport protocol, address family
+        byte transportByte = byteBuf.readByte();
+        assertEquals(0x00, transportByte);
+
+        // source address length
+        int sourceAddrLength = byteBuf.readUnsignedShort();
+        assertEquals(0, sourceAddrLength);
+
+        assertFalse(byteBuf.isReadable());
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidIpV4Address() {
+        String invalidIpv4Address = "192.168.0.1234";
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                invalidIpv4Address, "192.168.0.11", 56324, 443);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidIpV6Address() {
+        String invalidIpv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:73345";
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
+                invalidIpv6Address, "1050:0:0:0:5:600:300c:326b", 56324, 443);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidUnixAddress() {
+        String invalidUnixAddress = new String(new byte[UNIX_ADDRESS_BYTES_LENGTH + 1]);
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                invalidUnixAddress, "/var/run/dst.sock", 0, 0);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testNullUnixAddress() {
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                null, null, 0, 0);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testLongUnixAddress() {
+        String longUnixAddress = new String(new char[109]).replace("\0", "a");
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                "source", longUnixAddress, 0, 0);
+    }
+
+    @Test(expected = HAProxyProtocolException.class)
+    public void testInvalidUnixPort() {
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                "/var/run/src.sock", "/var/run/dst.sock", 80, 443);
+    }
+}

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>netty-codec-mqtt</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.haproxy;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyCommand;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyMessageEncoder;
+import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
+import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import io.netty.handler.codec.haproxy.HAProxySSLTLV;
+import io.netty.handler.codec.haproxy.HAProxyTLV;
+import io.netty.handler.codec.haproxy.HAProxyTLV.Type;
+import io.netty.util.CharsetUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static io.netty.example.haproxy.HAProxyServer.*;
+
+public final class HAProxyClient {
+
+    private static final String HOST = System.getProperty("host", "127.0.0.1");
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup group = new NioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+             .channel(NioSocketChannel.class)
+             .handler(new HAProxyMessageEncoder());
+
+            // Start the connection attempt.
+            Channel ch = b.connect(HOST, PORT).sync().channel();
+
+            HAProxyTLV alpnTlv = new HAProxyTLV(Type.PP2_TYPE_ALPN, Unpooled.EMPTY_BUFFER);
+            HAProxyTLV authorityTlv = new HAProxyTLV(
+                    Type.PP2_TYPE_AUTHORITY, Unpooled.copiedBuffer("authority".getBytes(CharsetUtil.US_ASCII)));
+            List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
+            tlvs.add(alpnTlv);
+            tlvs.add(authorityTlv);
+            HAProxySSLTLV sslTlv = new HAProxySSLTLV(1, (byte) 0x01, tlvs);
+
+            HAProxyMessage message = new HAProxyMessage(
+                    HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                    "127.0.0.1", "127.0.0.2", 8000, 9000,
+                    Collections.singletonList(sslTlv));
+            ch.writeAndFlush(message).sync();
+            ch.writeAndFlush(Unpooled.copiedBuffer("Hello World!", CharsetUtil.US_ASCII)).sync();
+            ch.writeAndFlush(Unpooled.copiedBuffer("Bye now!", CharsetUtil.US_ASCII)).sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.haproxy;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+public final class HAProxyServer {
+
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+             .channel(NioServerSocketChannel.class)
+             .handler(new LoggingHandler(LogLevel.INFO))
+             .childHandler(new HAProxyServerInitializer());
+            b.bind(PORT).sync().channel().closeFuture().sync();
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+
+    static class HAProxyServerInitializer extends ChannelInitializer<SocketChannel> {
+        @Override
+        public void initChannel(SocketChannel ch) throws Exception {
+            ch.pipeline().addLast(
+                    new LoggingHandler(LogLevel.DEBUG),
+                    new HAProxyMessageDecoder(),
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                            if (msg instanceof HAProxyMessage) {
+                                System.out.println("proxy message: " + msg);
+                            } else if (msg instanceof ByteBuf) {
+                                System.out.println("bytebuf message: " + ByteBufUtil.prettyHexDump((ByteBuf) msg));
+                            }
+                            super.channelRead(ctx, msg);
+                        }
+                    });
+        }
+    }
+}

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>netty-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HAProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HAProxyHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.proxy;
+
+import io.netty.channel.ChannelHandlerContext;
+
+import java.net.SocketAddress;
+
+public class HAProxyHandler extends ProxyHandler {
+
+    protected HAProxyHandler(SocketAddress proxyAddress) {
+        super(proxyAddress);
+    }
+
+    @Override
+    public String protocol() {
+        return null;
+    }
+
+    @Override
+    public String authScheme() {
+        return null;
+    }
+
+    @Override
+    protected void addCodec(ChannelHandlerContext ctx) throws Exception {
+
+    }
+
+    @Override
+    protected void removeEncoder(ChannelHandlerContext ctx) throws Exception {
+
+    }
+
+    @Override
+    protected void removeDecoder(ChannelHandlerContext ctx) throws Exception {
+
+    }
+
+    @Override
+    protected Object newInitialMessage(ChannelHandlerContext ctx) throws Exception {
+        return null;
+    }
+
+    @Override
+    protected boolean handleResponse(ChannelHandlerContext ctx, Object response) throws Exception {
+        return false;
+    }
+}

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HAProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HAProxyServer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.proxy;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
+import io.netty.util.CharsetUtil;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public class HAProxyServer extends ProxyServer {
+    protected HAProxyServer(boolean useSsl, TestMode testMode, InetSocketAddress destination) {
+        super(useSsl, testMode, destination);
+    }
+
+    @Override
+    protected void configure(SocketChannel ch) throws Exception {
+        ChannelPipeline p = ch.pipeline();
+        switch (testMode) {
+        case INTERMEDIARY:
+            p.addLast(new HAProxyMessageDecoder());
+            p.addLast(new HAProxyIntermediaryHandler());
+            break;
+        case TERMINAL:
+            p.addLast("lineDecoder", new LineBasedFrameDecoder(128, false, true));
+            p.addLast(new HAProxyMessageDecoder());
+            p.addLast(new HAProxyTerminalHandler());
+            break;
+        case UNRESPONSIVE:
+            p.addLast(UnresponsiveHandler.INSTANCE);
+            break;
+        }
+    }
+
+    private final class HAProxyIntermediaryHandler extends IntermediaryHandler {
+
+        private SocketAddress intermediaryDestination;
+
+        @Override
+        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (!(msg instanceof HAProxyMessage)) {
+                return false;
+            }
+
+            HAProxyMessage proxyMessage = (HAProxyMessage) msg;
+            intermediaryDestination = new InetSocketAddress(
+                    proxyMessage.destinationAddress(), proxyMessage.destinationPort());
+
+            ctx.pipeline().remove(HAProxyMessageDecoder.class);
+
+            return true;
+        }
+
+        @Override
+        protected SocketAddress intermediaryDestination() {
+            return intermediaryDestination;
+        }
+    }
+
+    private final class HAProxyTerminalHandler extends TerminalHandler {
+        @Override
+        protected boolean handleProxyProtocol(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (!(msg instanceof HAProxyMessage)) {
+                return false;
+            }
+
+            HAProxyMessage proxyMessage = (HAProxyMessage) msg;
+            if (!proxyMessage.destinationAddress().equals(destination.getHostString()) ||
+                proxyMessage.destinationPort() != destination.getPort()) {
+                ctx.close();
+                return false;
+            }
+            ctx.write(Unpooled.copiedBuffer("0\n", CharsetUtil.US_ASCII));
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Currently `HAProxyMessageEncoder`, `HAProxyMessageDecoder` only provides codecs for the PROXY protocol.
We may be able to integrate HAProxy with the other available `ProxyHandler` to offer high-order behavior + consistency.
This might be difficult as HAProxy differs slightly from other proxies -- mainly in that it doesn't require feedback before proceeding.
However, this option should be explored at the very least

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
